### PR TITLE
Update make_DESeq_heatmap.R

### DIFF
--- a/R_scripts/make_DESeq_heatmap.R
+++ b/R_scripts/make_DESeq_heatmap.R
@@ -37,6 +37,7 @@ cat ("Loading packages, may take a second...\n")
 suppressPackageStartupMessages({
   library(DESeq2)
   library("pheatmap")
+  library(genefilter)
   library(RColorBrewer)
   library(ggplot2)
 })


### PR DESCRIPTION
added 'library(genefilter)' to remove the following warning:

Error in rowVars(assay(transformed_data)) : 
  could not find function "rowVars"
Calls: head -> order -> standardGeneric -> eval -> eval -> eval
Execution halted