### PR TITLE
modify full_database_download.bash issue66

### DIFF
--- a/setup_and_test/full_database_download.bash
+++ b/setup_and_test/full_database_download.bash
@@ -23,7 +23,12 @@
 ####################################################################
 #
 # Set pathway for SAMSA to location of samsa2 GitHub download:
-source "${BASH_SOURCE%/*}/../bash_scripts/lib/common.sh"
+if [[ -d "${BASH_SOURCE%/*}/../bash_scripts/lib/common.sh" ]]; then
+  source "${BASH_SOURCE%/*}/../bash_scripts/lib/common.sh"
+else
+#assuming that you're running this full_database_download.bash directly ("bash full_database_download.bash")
+  source "../bash_scripts/lib/common.sh"
+fi
 
 # Make database directory
 mkdir $SAMSA/full_databases


### PR DESCRIPTION
From issue: [https://github.com/transcript/samsa2/issues/66](url)
I recently used full_database_download.bash and found an error message below.
full_database_download.bash: 26: full_database_download.bash: source: not found

So, I suggest to fix full_database_download.bash as shown below.

`source "${BASH_SOURCE%/*}/../bash_scripts/lib/common.sh"`
->

```
if [[ -d "${BASH_SOURCE%/*}/../bash_scripts/lib/common.sh" ]]; then
  source "${BASH_SOURCE%/*}/../bash_scripts/lib/common.sh"
else
#assuming that you're running this full_database_download.bash directly ("bash full_database_download.bash")
  source "../bash_scripts/lib/common.sh"
fi
```