### PR TITLE
Error correction (package_installation.bash and full_database_download.bash, issues66)

### DIFF
--- a/setup_and_test/full_database_download.bash
+++ b/setup_and_test/full_database_download.bash
@@ -23,7 +23,7 @@
 ####################################################################
 #
 # Set pathway for SAMSA to location of samsa2 GitHub download:
-if [[ -d "${BASH_SOURCE%/*}/../bash_scripts/lib/common.sh" ]]; then
+if [ -d "${BASH_SOURCE%/*}/../bash_scripts/lib/" ]; then
   source "${BASH_SOURCE%/*}/../bash_scripts/lib/common.sh"
 else
 #assuming that you're running this full_database_download.bash directly ("bash full_database_download.bash")

--- a/setup_and_test/package_installation.bash
+++ b/setup_and_test/package_installation.bash
@@ -31,7 +31,7 @@
 # Set pathway for SAMSA to location of samsa2 GitHub download:
 IGNORE_DEPS=1 
 
-if [[ -d "${BASH_SOURCE%/*}/../bash_scripts/lib/common.sh" ]]; then
+if [ -d "${BASH_SOURCE%/*}/../bash_scripts/lib/" ]; then
   source "${BASH_SOURCE%/*}/../bash_scripts/lib/common.sh"
 else
   # assuming that you're running this package_installation.bash script directly ("bash package_installation.bash")


### PR DESCRIPTION
From issue: https://github.com/transcript/samsa2/issues/66

1. Error meassage of package_installation.bash
command : bash setup_and_test/package_installation.bash
Error message : setup_and_test/package_installation.bash: line 38: ../bash_scripts/lib/common.sh: No such file or directory

2. Error meassage of full_database_download.bash
command : bash setup_and_test/full_database_download.bash
Error message : setup_and_test/full_database_download.bash: line 32: ../bash_scripts/lib/common.sh: No such file or directory

Hence, I suggest to fix package_installation.bash (and full_database_download.bash) as shown below.

`if [[ -d "${BASH_SOURCE%/*}/../bash_scripts/lib/common.sh" ]]; then`
->
`if [ -d "${BASH_SOURCE%/*}/../bash_scripts/lib/" ]; then`