### PR TITLE
More flexible filename handling

### DIFF
--- a/R_scripts/Subsystems_DESeq_stats.R
+++ b/R_scripts/Subsystems_DESeq_stats.R
@@ -185,23 +185,18 @@ l1_table[is.na(l1_table)] <- 0
 # OPTIONAL: importing the raw counts
 cat ("Now importing raw counts, if provided.\n")
 if (is.null(opt$raw_counts) == FALSE) {
-  raw_counts_table <- read.table(counts_file, header=FALSE, sep = "\t", quote = "")
-  raw_counts_table <- data.frame(raw_counts_table, 
-        do.call(rbind, strsplit(as.character(raw_counts_table$V1),'_')))
-  raw_counts_table$X2 <- as.numeric(as.character(raw_counts_table$X2))
-  raw_counts_table <- t(raw_counts_table[,c("X2", "V2")])
-  row.names(raw_counts_table) <- c("SAMPLE","RAW TOTAL")
-  colnames(raw_counts_table) <- raw_counts_table[1,]
-  raw_counts_table <- as.data.frame(raw_counts_table)
-  raw_counts_table <- raw_counts_table[-1,]
+  raw_counts_table <- read.delim(counts_file, header=FALSE, col.names=c("FILESTEM", "RAW_TOTAL"), quote = "")
   
-  # Need to subtract off the total number of annotations
-  raw_counts_table["ANNOTATION COUNT",] <- colSums(l1_table)
-  raw_counts_table["OTHER",] <- raw_counts_table[1,] - raw_counts_table[2,]
-  
-  l1_table <- rbind(l1_table, raw_counts_table["OTHER",])
-  l1_names <- c(l1_names, "OTHER")
-  rownames(l1_table) <- l1_names
+  # Extract sample names from filestems
+  raw_counts_table[, "SAMPLE"] <- gsub("experimental_|control_|.cleaned", "", raw_counts_table$FILESTEM)
+
+  # Subtract the annotation count from total to obtain unannotated count
+  raw_counts_table[, "ANNOTATION_COUNT"] <- colSums(l1_table)
+  raw_counts_table[, "OTHER"] <- raw_counts_table["RAW_TOTAL"] - raw_counts_table["ANNOTATION_COUNT"]
+
+  # Append unannotated counts to complete table
+  other_counts_table <- t(data.frame("OTHER"=raw_counts_table[, "OTHER"], row.names=raw_counts_table[, "SAMPLE"]))
+  l1_table <- rbind(l1_table, other_counts_table)
 }
 
 # now the DESeq stuff


### PR DESCRIPTION
This is a fix for https://github.com/transcript/samsa2/issues/81, where `run_DESeq_stats.R` and `Subsystems_DESeq_stats.R` will fail if filenames do not follow the pattern `experimental_#_...` or `control_#_...`.

Rather than splitting the filenames by underscores, the new code removes `experimental_` or `control_` from the beginning and `.cleaned` from the end in order to get the sample names for matching.

Also, I solved the problem of R wanting to change the counts to factors by setting the sample names as row names before transposing. (Previously, if the sample names were not numeric, transposing the dataframe would create columns that were mixed so R would convert all columns to factors. Pulling the sample names into the row names before transposing allows them to directly become column names without affecting the data types.)

Thank you and let me know if you have any questions!